### PR TITLE
Replace support lib dependencies with AndroidX

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ buildscript {
   ext.kotlin_version = '1.3.40'
 
   repositories {
-    jcenter()
     google()
+    jcenter()
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.4.1'
@@ -15,8 +15,8 @@ buildscript {
 
 allprojects {
   repositories {
-    jcenter()
     google()
+    jcenter()
     maven {
       url "https://s3.amazonaws.com/repo.commonsware.com"
     }

--- a/document/build.gradle
+++ b/document/build.gradle
@@ -1,9 +1,11 @@
 apply plugin: 'com.android.library'
 
 dependencies {
-    implementation 'com.android.support:support-annotations:28.0.0'
-    androidTestImplementation 'com.android.support.test:rules:1.0.2'
-    androidTestImplementation 'com.android.support:support-compat:28.0.0'
+    implementation "androidx.annotation:annotation:1.1.0"
+
+    androidTestImplementation "androidx.test:runner:1.3.0"
+    androidTestImplementation "androidx.test:rules:1.3.0"
+    androidTestImplementation "androidx.core:core:1.3.1"
 }
 
 android {
@@ -13,7 +15,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 28
         testApplicationId "com.commonsware.cwac.document.test"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {

--- a/document/src/androidTest/java/com/commonsware/cwac/document/IOTests.java
+++ b/document/src/androidTest/java/com/commonsware/cwac/document/IOTests.java
@@ -19,22 +19,17 @@ package com.commonsware.cwac.document;
 import android.content.Context;
 import android.net.Uri;
 import android.os.Build;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
-import android.support.v4.content.FileProvider;
+import androidx.core.content.FileProvider;
+import androidx.test.InstrumentationRegistry;
+import androidx.test.runner.AndroidJUnit4;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import java.io.DataInputStream;
-import java.io.EOFException;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+
+import java.io.*;
+
+import static org.junit.Assert.*;
 
 @RunWith(AndroidJUnit4.class)
 public class IOTests {
@@ -46,7 +41,7 @@ public class IOTests {
 
   @Before
   public void init() {
-    ctxt=InstrumentationRegistry.getContext();
+    ctxt= InstrumentationRegistry.getContext();
   }
 
   @After
@@ -118,7 +113,7 @@ public class IOTests {
 
     assertFalse(f.exists());
 
-    Uri test=FileProvider.getUriForFile(ctxt, AUTHORITY, f);
+    Uri test= FileProvider.getUriForFile(ctxt, AUTHORITY, f);
     DocumentFileCompat df=builder.buildFrom(ctxt, test);
 
     assertFalse(df.exists());

--- a/document/src/main/java/com/commonsware/cwac/document/DocumentsContractApi19.java
+++ b/document/src/main/java/com/commonsware/cwac/document/DocumentsContractApi19.java
@@ -25,9 +25,10 @@ import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.net.Uri;
 import android.provider.DocumentsContract;
-import android.support.annotation.RequiresApi;
 import android.text.TextUtils;
 import android.util.Log;
+import androidx.annotation.RequiresApi;
+
 import java.io.FileNotFoundException;
 
 @RequiresApi(19)

--- a/document/src/main/java/com/commonsware/cwac/document/DocumentsContractApi21.java
+++ b/document/src/main/java/com/commonsware/cwac/document/DocumentsContractApi21.java
@@ -23,8 +23,8 @@ import android.content.Context;
 import android.database.Cursor;
 import android.net.Uri;
 import android.provider.DocumentsContract;
-import android.support.annotation.RequiresApi;
 import android.util.Log;
+import androidx.annotation.RequiresApi;
 
 import java.io.FileNotFoundException;
 import java.util.ArrayList;

--- a/document/src/main/java/com/commonsware/cwac/document/RawDocumentFile.java
+++ b/document/src/main/java/com/commonsware/cwac/document/RawDocumentFile.java
@@ -17,7 +17,6 @@
 
 package com.commonsware.cwac.document;
 
-import android.content.Context;
 import android.net.Uri;
 import android.util.Log;
 import android.webkit.MimeTypeMap;

--- a/document/src/main/java/com/commonsware/cwac/document/SingleDocumentFile.java
+++ b/document/src/main/java/com/commonsware/cwac/document/SingleDocumentFile.java
@@ -21,11 +21,11 @@ import android.annotation.TargetApi;
 import android.content.Context;
 import android.net.Uri;
 import android.os.Build;
-import android.support.annotation.RequiresApi;
 import android.webkit.MimeTypeMap;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import androidx.annotation.RequiresApi;
 
 @RequiresApi(19)
 @TargetApi(19)

--- a/document/src/main/java/com/commonsware/cwac/document/TreeDocumentFile.java
+++ b/document/src/main/java/com/commonsware/cwac/document/TreeDocumentFile.java
@@ -20,10 +20,9 @@ package com.commonsware.cwac.document;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.net.Uri;
-import android.support.annotation.RequiresApi;
-import android.webkit.MimeTypeMap;
+import androidx.annotation.RequiresApi;
+
 import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
@@ -41,14 +40,14 @@ class TreeDocumentFile extends DocumentFileCompat {
 
     @Override
     public DocumentFileCompat createFile(String mimeType, String displayName)
-      throws FileNotFoundException {
+            throws FileNotFoundException {
         final Uri result = DocumentsContractApi21.createFile(mContext, mUri, mimeType, displayName);
         return (result != null) ? new TreeDocumentFile(this, mContext, result) : null;
     }
 
     @Override
     public DocumentFileCompat createDirectory(String displayName)
-      throws FileNotFoundException {
+            throws FileNotFoundException {
         final Uri result = DocumentsContractApi21.createDirectory(mContext, mUri, displayName);
         return (result != null) ? new TreeDocumentFile(this, mContext, result) : null;
     }
@@ -118,7 +117,7 @@ class TreeDocumentFile extends DocumentFileCompat {
         final Uri[] resultDocs = DocumentsContractApi21.listContent(mContext, mUri, false);
         final Uri[] resultTrees = DocumentsContractApi21.listContent(mContext, mUri, true);
         final DocumentFileCompat[] resultFiles =
-          new DocumentFileCompat[resultDocs.length + resultTrees.length];
+                new DocumentFileCompat[resultDocs.length + resultTrees.length];
 
         for (int i = 0; i < resultTrees.length; i++) {
             resultFiles[i] = new TreeDocumentFile(this, mContext, resultTrees[i]);
@@ -144,18 +143,18 @@ class TreeDocumentFile extends DocumentFileCompat {
 
     @Override
     public InputStream openInputStream()
-      throws FileNotFoundException {
+            throws FileNotFoundException {
         throw new UnsupportedOperationException("Cannot open a stream on a tree");
     }
 
     @Override
     public OutputStream openOutputStream()
-      throws FileNotFoundException {
+            throws FileNotFoundException {
         throw new UnsupportedOperationException("Cannot open a stream on a tree");
     }
 
     @Override
     public String getExtension() {
-        return(null);
+        return (null);
     }
 }


### PR DESCRIPTION
This cwac-document was flagged by [can-i-drop-jetifier](https://github.com/plnice/can-i-drop-jetifier) plugin due to use of the support-annotations library. This PR migrates to Android X annotations with no functional changes. 

⚠️ I had issues with running the instrumentation tests (IOTests) failed with `Test running failed: Process crashed.` - wonder if I'm missing something simple?  
